### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.0.4
+### Fixed
+- Fix `AlbumByName` to check against all Google Photos album list (#12).
+
 ## 1.0.3
 ### Added
 - Add resumable file uploads. You can use new `UploadFileResumable` method to upload files that can be resumed. See [documentation](https://godoc.org/github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos) for more details.


### PR DESCRIPTION
## 1.0.4
### Fixed
- Fix `AlbumByName` to check against all Google Photos album list (#12).