### PR TITLE
Add Code quality and coverage reports

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,31 @@
+---
+kind: pipeline
+name: go-1-11
+
+steps:
+  - name: test-lint-build
+    image: golang:1.11
+    volumes:
+      - name: deps
+        path: /go
+    commands:
+      - make test COVERAGE_FILE=coverage.txt
+      - make lint
+
+  - name: coverage
+    image: plugins/codecov
+    settings:
+      required: true
+      token:
+        from_secret: codecov_token
+    files:
+     - coverage.txt
+
+volumes:
+  - name: deps
+    temp: {}
+---
+kind: signature
+hmac: 35e5fc870ab883e2c74b9b5c53a4fbe906f132354f07e834f0a90d07c1d1035b
+
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: go
-env:
-  matrix:
-    - GO111MODULE=on
-go:
-- 1.11.x
-script:
-- make ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Added
+- Code quality reporting using [Codebeat](https://codebeat.co/projects/github-com-gphotosuploader-google-photos-api-client-go-master).
+- Code coverage reporting using [codecov](https://codecov.io/gh/gphotosuploader/google-photos-api-client-go).
+
+### Changed
+- CI platform is now [drone.io](https://drone.io).
+
 ## 1.0.4
 ### Fixed
 - Fix `AlbumByName` to check against all Google Photos album list (#12).

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # go source files, ignore vendor directory
 PKGS = $(shell go list ./... | grep -v /vendor)
-COVERAGE_FILE := coverage.txt
+COVERAGE_FILE ?= coverage.txt
 
 # Get first path on multiple GOPATH environments
 GOPATH := $(shell echo ${GOPATH} | cut -d: -f1)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Google Photos API client (Go library)
-[![Build Status](https://img.shields.io/travis/com/gphotosuploader/google-photos-api-client-go.svg?style=flat-square)](https://travis-ci.com/gphotosuploader/google-photos-api-client-go)
+[![Build Status](https://cloud.drone.io/api/badges/gphotosuploader/google-photos-api-client-go/status.svg)](https://cloud.drone.io/gphotosuploader/google-photos-api-client-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gphotosuploader/google-photos-api-client-go)](https://goreportcard.com/report/github.com/gphotosuploader/google-photos-api-client-go)
+[![codebeat badge](https://codebeat.co/badges/c0ab08dd-11b3-406e-bbcc-b9d4a90aedf6)](https://codebeat.co/projects/github-com-gphotosuploader-google-photos-api-client-go-master)
+[![codecov](https://codecov.io/gh/gphotosuploader/google-photos-api-client-go/branch/master/graph/badge.svg)](https://codecov.io/gh/gphotosuploader/google-photos-api-client-go)
+[![GitHub release](https://img.shields.io/github/release/gphotosuploader/google-photos-api-client-go.svg)](https://github.com/gphotosuploader/google-photos-api-client-go/releases/latest)
+[![GitHub](https://img.shields.io/github/license/gphotosuploader/google-photos-api-client-go.svg)](LICENSE)
 
 This is a [Google Photos API client]() based on the official Google Photos API client library, that [was removed](https://code-review.googlesource.com/c/google-api-go-client/+/39951) from [Google API client library for Go](https://godoc.org/google.golang.org/api) and it was mirrored [here](https://github.com/gphotosuploader/googlemirror). 
 


### PR DESCRIPTION
### Added
- Code quality reporting using [Codebeat](https://codebeat.co/projects/github-com-gphotosuploader-google-photos-api-client-go-master).
- Code coverage reporting using [codecov](https://codecov.io/gh/gphotosuploader/google-photos-api-client-go).

### Changed
- CI platform is now [drone.io](https://drone.io).