### PR TITLE
Fix issue #28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 1.1.2
+### Changed
+- Update [golangci](https://github.com/golangci/golangci-lint) linter to version 1.20.0.
 ### Fixed
 - Fix fatal error introduced in the last version. (#28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 1.1.2
+### Fixed
+- Fix fatal error introduced in the last version. (#28)
+
 ## 1.1.1
 ### Fixed
 - Fix race condition on `GetOrCreateAlbumByName()`. Google Photos API allow you to create several albums with the same name. (#26)

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ clean: ## Clean all built artifacts
 BIN_DIR := $(GOPATH)/bin
 
 GOLANGCI := $(BIN_DIR)/golangci-lint
-GOLANGCI_VERSION := 1.12.3
+GOLANGCI_VERSION := 1.20.0
 
 $(GOLANGCI):
 	@echo "--> Installing golangci v$(GOLANGCI_VERSION)..."

--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -20,7 +20,7 @@ type Client struct {
 	uploader *uploader.Uploader
 
 	log *log.Logger
-	mu  *sync.Mutex
+	mu  sync.Mutex
 
 	token *oauth2.Token // DEPRECATED: `token` will disappear in the next MAJOR version.
 }

--- a/noserver-gphotos/libwrapper.go
+++ b/noserver-gphotos/libwrapper.go
@@ -4,7 +4,7 @@ import gphotos "github.com/gphotosuploader/google-photos-api-client-go/lib-gphot
 
 // DEPRECATED
 type Client struct {
-	gphotos.Client
+	*gphotos.Client
 }
 
 type APIAppCredentials gphotos.APIAppCredentials

--- a/noserver-gphotos/no-server.go
+++ b/noserver-gphotos/no-server.go
@@ -32,7 +32,7 @@ func NewClient(options ...ClientConstructorOption) (client *Client, merr error) 
 			merr = multierror.Append(merr, err)
 			continue
 		}
-		return &Client{*gphotosClient}, nil
+		return &Client{gphotosClient}, nil
 	}
 	// if all constructor options failed, returned errors returned by each option
 	return nil, stacktrace.Propagate(merr, "all options failed with errors:")


### PR DESCRIPTION
An incorrect Mutex definition was used on the previous version.
```
type Client struct {
        // Some lines has been removed
	log *log.Logger
	mu *sync.Mutex
}
```
The correct one is:
```
type Client struct {
        // Some lines has been removed
	log *log.Logger
	mu sync.Mutex
}
```
Closes #28 