### PR TITLE
Deprecate go-1-11 support in favor of go-1-13

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,6 @@ trigger:
 
 ---
 kind: signature
-hmac: cda23a221a730cd62ef0bf7a9885206085d42654c088eceda87725ddf0162af8
+hmac: a43206f48694a7bc70f9aeaac516f7ca71ce7bd28fe04ad23cb3d4fbea273081
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,16 +1,48 @@
 ---
 kind: pipeline
-name: go-1-11
+name: test
+
+platform:
+  os: linux
+  arch: amd64
 
 steps:
-  - name: test-lint-build
-    image: golang:1.11
+  - name: test-build
+    image: golang:1.13
+    commands:
+      - make test
+      - make build
+
+trigger:
+  branch:
+    exclude:
+      - master
+
+---
+kind: pipeline
+name: test-master-go-1-13
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: test-build
+    image: golang:1.13
+    commands:
+      - make test COVERAGE_FILE=coverage.txt
+      - make build
     volumes:
       - name: deps
         path: /go
+
+  - name: lint
+    image: golang:1.13
     commands:
-      - make test COVERAGE_FILE=coverage.txt
       - make lint
+    volumes:
+      - name: deps
+        path: /go
 
   - name: coverage
     image: plugins/codecov
@@ -18,14 +50,36 @@ steps:
       required: true
       token:
         from_secret: codecov_token
-    files:
-     - coverage.txt
 
 volumes:
   - name: deps
     temp: {}
+
+trigger:
+  branch:
+    - master
+
+---
+kind: pipeline
+name: test-master-go-1-12
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: test-build
+    image: golang:1.12
+    commands:
+      - make test
+      - make build
+
+trigger:
+  branch:
+    - master
+
 ---
 kind: signature
-hmac: 35e5fc870ab883e2c74b9b5c53a4fbe906f132354f07e834f0a90d07c1d1035b
+hmac: cda23a221a730cd62ef0bf7a9885206085d42654c088eceda87725ddf0162af8
 
 ...

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug'
+assignees: 'pacoorozco'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Do tath on '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature request'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+**What issue type does this pull request address?** (keep at least one, remove the others)  
+/kind bug
+/kind enhancement
+/kind feature
+/kind documentation
+
+
+**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
+resolves #
+
+
+**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
+
+
+**Does this pull request add new dependencies?**  
+
+
+**What else do we need to know?**  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Added
+- [CONTRIBUTING](CONTRIBUTING.md) guide line has been added.
+### Changed
+- [README](README.md) has been updated fixing some typos.
+### Deprecated
+- Once Go 1.13 has been published, previous Go 1.11 support is deprecated. This project will maintain compatibility with the last two major versions published.
+
 ## 1.1.2
 ### Changed
 - Update [golangci](https://github.com/golangci/golangci-lint) linter to version 1.20.0.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at pakus@pakusland.net. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contribution Guidelines
+Please read this guide if you plan to contribute to this project. We welcome any kind of contribution. No matter if you are an experienced programmer or just starting, we are looking forward to your contribution.
+
+## Reporting Issues
+If you find a bug while using this module, please [open an issue on GitHub](https://github.com/gphotosuploader/google-photos-api-client-go/issues/new?assignees=pacoorozco&labels=bug&template=bug_report.md) and let us know what went wrong. We will try to fix it as quickly as we can.
+
+## Feature Requests
+You are more than welcome to open issues in this project to [suggest new features](https://github.com/gphotosuploader/google-photos-api-client-go/issues/new?assignees=&labels=feature+request&template=feature_request.md).
+
+## Contributing Code
+This project is mainly written in Golang.
+
+> This project will maintain compatibility with the last two Go major versions published. Currently Go 1.12 and Go 1.13.
+
+To contribute code:
+1. Ensure you are running golang version 1.12 or greater
+2. Set the following environment variables:
+    ```
+    GO111MODULE=on
+    ```
+3. Fork the project
+4. Clone the project: `git clone https://github.com/[YOUR_USERNAME]/gphotos-uploader-cli && cd gphotos-uploader-cli`
+5. Run `go mod download` to install the dependencies
+6. Make changes to the code
+7. Run `make build` to build the project
+8. Make changes
+9. Run tests: `make test`
+10. Format your code: `go fmt ./...`
+11. Commit changes
+12. Push commits
+13. Open pull request

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Photos API client (Go library)
+# Google Photos API client for Go
 [![Go Documentation](https://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](https://godoc.org/github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos)
 [![Build Status](https://cloud.drone.io/api/badges/gphotosuploader/google-photos-api-client-go/status.svg)](https://cloud.drone.io/gphotosuploader/google-photos-api-client-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/gphotosuploader/google-photos-api-client-go)](https://goreportcard.com/report/github.com/gphotosuploader/google-photos-api-client-go)
@@ -9,6 +9,9 @@
 
 This package provides a client for using the [Google Photos API](https://godoc.org/google.golang.org/api). Uses the [original Google Photos package](https://github.com/gphotosuploader/googlemirror), that was provided by Google, and [removed](https://code-review.googlesource.com/c/google-api-go-client/+/39951) some time ago. On top of the old package has been extended some other features like uploads, including resumable uploads.
 
+
+> This project will maintain compatibility with the last two Go major versions published. Currently Go 1.12 and Go 1.13. 
+>
 ## Quick start
 
 Construct a new Google Photos client, then use the various services on the client to access different parts of the Google Photos API. For example:

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,5 @@ require (
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
-	golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522
 	google.golang.org/api v0.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,6 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522 h1:bhOzK9QyoD0ogCnFro1m2mz41+Ib0oOhfJnBp5MR4K4=
-golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/lib-gphotos/albums.go
+++ b/lib-gphotos/albums.go
@@ -2,9 +2,9 @@ package gphotos
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gphotosuploader/googlemirror/api/photoslibrary/v1"
-	"golang.org/x/xerrors"
 )
 
 const (
@@ -13,7 +13,7 @@ const (
 
 var (
 	// ErrAlbumNotFound represents a failure to find the album.
-	ErrAlbumNotFound = xerrors.New("specified album was not found")
+	ErrAlbumNotFound = errors.New("specified album was not found")
 )
 
 // albumByNameWithPageToken checks for the specified album recursively. Google Photos returns

--- a/lib-gphotos/client_test.go
+++ b/lib-gphotos/client_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gphotosuploader/google-photos-api-client-go/lib-gphotos/internal/uploader"
 )
 
-type mockUploadSessionStore struct {}
+type mockUploadSessionStore struct{}
 
 func (m *mockUploadSessionStore) Get(f string) []byte {
 	return []byte(f)

--- a/lib-gphotos/internal/uploader/errors.go
+++ b/lib-gphotos/internal/uploader/errors.go
@@ -1,7 +1,7 @@
 package uploader
 
-import "golang.org/x/xerrors"
+import "errors"
 
 var (
-	ErrNilStore = xerrors.New("store can't be nil if Resume is enable")
+	ErrNilStore = errors.New("store can't be nil if Resume is enable")
 )

--- a/lib-gphotos/internal/uploader/upload.go
+++ b/lib-gphotos/internal/uploader/upload.go
@@ -7,21 +7,19 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
-
-	"golang.org/x/xerrors"
 )
 
 // UploadFromFile returns the Google Photos upload token for the file.
 func (u *Uploader) UploadFromFile(ctx context.Context, filename string) (string, error) {
 	file, err := os.Open(filename)
 	if err != nil {
-		return "", xerrors.Errorf("failed opening file: err=%w", err)
+		return "", fmt.Errorf("failed opening file: err=%s", err)
 	}
 	defer file.Close()
 
 	fileStat, err := file.Stat()
 	if err != nil {
-		return "", xerrors.Errorf("failed getting file size: file=%s, err=%w", filename, err)
+		return "", fmt.Errorf("failed getting file size: file=%s, err=%s", filename, err)
 	}
 	size := fileStat.Size()
 

--- a/lib-gphotos/internal/uploader/uploader_test.go
+++ b/lib-gphotos/internal/uploader/uploader_test.go
@@ -53,7 +53,7 @@ func TestNewUploader(t *testing.T) {
 	})
 }
 
-type mockUploadSessionStore struct {}
+type mockUploadSessionStore struct{}
 
 func (m *mockUploadSessionStore) Get(f string) []byte {
 	return []byte(f)

--- a/lib-gphotos/retries.go
+++ b/lib-gphotos/retries.go
@@ -2,12 +2,12 @@ package gphotos
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
 
 	"github.com/gphotosuploader/googlemirror/api/photoslibrary/v1"
-	"golang.org/x/xerrors"
 	"google.golang.org/api/googleapi"
 )
 
@@ -48,8 +48,8 @@ func (c *Client) retryableMediaItemBatchCreateDo(ctx context.Context, request *p
 				continue
 			}
 		}
-		return nil, xerrors.Errorf("unexpected error response: file=%s, err=%w", filename, err)
+		return nil, fmt.Errorf("unexpected error response: file=%s, err=%s", filename, err)
 
 	}
-	return res, xerrors.Errorf("too many retries: file=%s, err=%w", filename, err)
+	return res, fmt.Errorf("too many retries: file=%s, err=%s", filename, err)
 }

--- a/lib-gphotos/uploads.go
+++ b/lib-gphotos/uploads.go
@@ -83,4 +83,5 @@ func (c *Client) UploadFileResumable(filePath string, uploadURL *string, pAlbumI
 	}
 	return c.UploadFile(filePath)
 }
+
 // codebeat:enable

--- a/lib-gphotos/uploads.go
+++ b/lib-gphotos/uploads.go
@@ -2,9 +2,10 @@ package gphotos
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/gphotosuploader/googlemirror/api/photoslibrary/v1"
-	"golang.org/x/xerrors"
 )
 
 // AddMediaItem returns MediaItem created after uploading `filename` and adding it to `albumID`.
@@ -13,7 +14,7 @@ func (c *Client) AddMediaItem(ctx context.Context, filename, albumID string) (*p
 
 	uploadToken, err := c.uploader.UploadFromFile(ctx, filename)
 	if err != nil {
-		return nil, xerrors.Errorf("failed getting uploadToken for %s: err=%w", filename, err)
+		return nil, fmt.Errorf("failed getting uploadToken for %s: err=%s", filename, err)
 	}
 
 	c.log.Printf("[DEBUG] File has been uploaded: file=%s", filename)
@@ -21,7 +22,7 @@ func (c *Client) AddMediaItem(ctx context.Context, filename, albumID string) (*p
 	mediaItem, err := c.createMediaItemFromUploadToken(ctx, uploadToken, albumID, filename)
 	if err != nil {
 		c.log.Printf("[ERR] Failed to create media item: file=%s, err=%s", filename, err)
-		return nil, xerrors.Errorf("Error while trying to create this media item, err=%s", err)
+		return nil, fmt.Errorf("error while trying to create this media item, err=%s", err)
 	}
 
 	c.log.Printf("File uploaded and media item created successfully: file=%s", filename)
@@ -45,19 +46,20 @@ func (c *Client) createMediaItemFromUploadToken(ctx context.Context, uploadToken
 	}
 
 	if res == nil || len(res.NewMediaItemResults) != 1 {
-		return nil, xerrors.New("len(batchResults) should be 1")
+		return nil, errors.New("len(batchResults) should be 1")
 	}
 
 	result := res.NewMediaItemResults[0]
 	// `result.Status.Code` has the GRPC code returned by Google Photos API. Values can be obtained at
 	// https://godoc.org/google.golang.org/genproto/googleapis/rpc/code
 	if result.Status.Code != 0 {
-		return nil, xerrors.New(result.Status.Message)
+		return nil, errors.New(result.Status.Message)
 	}
 	return result.MediaItem, nil
 }
 
 // codebeat:disable
+
 // UploadFile actually uploads the media and activates it on google photos
 // DEPRECATED: Use c.AddMediaItem(...) instead
 func (c *Client) UploadFile(filename string, pAlbumID ...string) (*photoslibrary.MediaItem, error) {
@@ -65,7 +67,7 @@ func (c *Client) UploadFile(filename string, pAlbumID ...string) (*photoslibrary
 
 	// validate parameters
 	if len(pAlbumID) > 1 {
-		return nil, xerrors.New("parameters can't include more than one albumID'")
+		return nil, errors.New("parameters can't include more than one albumID'")
 	}
 	var albumID string
 	if len(pAlbumID) == 1 {


### PR DESCRIPTION
**What issue type does this pull request address?** 
enhancement

**What is this pull request for?**
Once Go 1.13 has been released, the previous Go 1.11 support is deprecated. This project will maintain compatibility with the last two Go major versions published: currently 1.12 and 1.13.

**Does this pull request has user-facing changes?** 
Requirements to compile are now Go 1.12+