### PR TITLE
Cache Albums that we already found or that we created

### DIFF
--- a/lib-gphotos/client.go
+++ b/lib-gphotos/client.go
@@ -17,7 +17,8 @@ type Client struct {
 	// Google Photos client
 	*photoslibrary.Service
 	// Uploader to upload new files to Google Photos
-	uploader *uploader.Uploader
+	uploader            *uploader.Uploader
+	createdAlbumsByName map[string]*photoslibrary.Album
 
 	log log.Logger
 	mu  sync.Mutex
@@ -42,9 +43,10 @@ func NewClientWithResumableUploads(httpClient *http.Client, store uploader.Uploa
 	}
 
 	c := &Client{
-		Service:  photosService,
-		uploader: upldr,
-		log:      log.NewDiscardLogger(),
+		Service:             photosService,
+		uploader:            upldr,
+		log:                 log.NewDiscardLogger(),
+		createdAlbumsByName: make(map[string]*photoslibrary.Album),
 	}
 
 	for _, opt := range options {
@@ -90,9 +92,10 @@ func NewClient(httpClient *http.Client, maybeToken ...*oauth2.Token) (*Client, e
 	}
 
 	c := &Client{
-		Service:  photosService,
-		uploader: upldr,
-		log:      log.NewDiscardLogger(),
+		Service:             photosService,
+		uploader:            upldr,
+		log:                 log.NewDiscardLogger(),
+		createdAlbumsByName: make(map[string]*photoslibrary.Album),
 	}
 
 	c.token = token


### PR DESCRIPTION
It's common to call `GetOrCreateAlbumByName` several times for a same Album. Instead of going through all the albums each time this happens, this caches the result (both if we found the Album or if we created it). This also solves the problem where one Album wasn't returned by `AlbumByName` right after it was created (probably due to eventual consistency) causing two successive calls to `GetOrCreateAlbumByName` to create two albums with the same name.

/kind enhancement
/kind bug
Fixes https://github.com/gphotosuploader/gphotos-uploader-cli/issues/192

