### PR TITLE
Add an HTTP client with retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Improved testing of the whole module.
 - Added `ListAlbums` and `ListAlbumsWithCallback`, to get album list from library.
 - Added `AddMediaToLibrary` to upload media without assigning it to an album.
+- Added retries on HTTP Client. The default configuration will use Exponential Backoff with a maximum of 5 retries.
 ### Changed
 - Import path includes **v2**: `github.com/gphotosuploader/google-photos-api-client-go/v2`.
 - Client call has changes to `NewClient` where you can customize with `Options`. See [README](README.md) for more information.

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 [![GitHub](https://img.shields.io/github/license/gphotosuploader/google-photos-api-client-go.svg)](LICENSE)
 
 This package provides a client for using the [Google Photos API](https://godoc.org/google.golang.org/api) in Go. Uses the [original Google Photos package](https://github.com/gphotosuploader/googlemirror), that was provided by Google, and [removed](https://code-review.googlesource.com/c/google-api-go-client/+/39951) some time ago. 
-
-On top of the old package has been extended some other features like:
- 
- * Uploads: We have implemented the `/v1/uploads` endpoint to be able to upload media items to your library. Two implementations are available: a `BasicUploader` and a `ResumableUploader` which could be used for large files, like videos. See [Options](#options) 
  
 > This project will maintain compatibility with the last two Go major versions [published](https://golang.org/doc/devel/release.html). 
 
@@ -50,11 +46,12 @@ func main() error {
 
 ## Features
 
+* **Two uploaders**: We have implemented the `/v1/uploads` endpoint to be able to upload media items to your library. Two implementations are available: a `BasicUploader` and a `ResumableUploader` which could be used for large files, like videos. See [Options](#options) 
 * **Uploads**: `AddMediaToLibrary` and `AddMediaToAlbum` allows you to upload media to the the libray.
 * **Album management**: `ListAlbums`, `FindAlbum` and `CreateAlbum` allows you to list, find an album by title and create a new album in the library. 
 * `ListAlbumsWithCallback` allows you to call a function while browse the albums in the library.
 * **Automatic cache**, following [Google Photos best practices](https://developers.google.com/photos/library/guides/best-practices#caching), a cache is used to increase performance and reduce the number of calls to the Google Photos API (see [Rate Limiting](#rate-limiting).
-* **Automatic retries**: It implements retries following [Google Photos error handling documentation](https://developers.google.com/photos/library/guides/best-practices#error-handling). 
+* **Automatic retries**: It implements retries following [Google Photos error handling documentation](https://developers.google.com/photos/library/guides/best-practices#error-handling). By default it uses exponential backoff with a maximum of 5 retries.
 
 ## Options 
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/duffpl/google-photos-api-client v0.2.0
 	github.com/gadelkareem/cachita v0.2.1
 	github.com/gphotosuploader/googlemirror v0.5.0
+	github.com/hashicorp/go-retryablehttp v0.6.8
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
 	google.golang.org/api v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,12 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gphotosuploader/googlemirror v0.5.0 h1:9a9CCUnAFo3qHp7U/epmdTiOvAzXCkVq5AQLo8PWBns=
 github.com/gphotosuploader/googlemirror v0.5.0/go.mod h1:L6A+2KW6d/OwjZ5QH2fGXJXsOtR115tj9w+YxdyjfUI=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
+github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/imdario/mergo v0.3.10 h1:6q5mVkdH/vYmqngx7kZQTjJ5HRsx+ImorDIEQ+beJgc=


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind enhancement

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
Add retries to request to Google API. It's implementing exponential back-off with maximum 5 retries.

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
If a recoverable error happens while calling Google Photos API, this client will try to retry.

**Does this pull request add new dependencies?**  
`github.com/hashicorp/go-retryablehttp`

