### PR TITLE
albums.ListWithOptions() method allows excluding non-app-created albums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 - Support for `go` version `1.17`.
 - Pagination to the mediaItems:search mock.
+- `ListWithOptions()` method to list all albums specifying if non app created albums should be returned or not. ([#72][i72])
 ### Changed
 - Reduce number of request to Google Photos by using bigger `PageSize` on `mediaItems.search` and `albums.list`.
 ### Fixed
+- `ListAll()` method use `excludeNonAppCreatedData` and it doesn't return all albums. ([#72][i72])
+  > This could be a breaking change, given that we were excluding non app created albums previously. If you want to maintain the same behaviour as before, use `ListWithOptions()` instead.
 - `MediaItems.ListByAlbum` does not support paging. ([#65][i65])
 ### Removed
 - Support for `go` version `1.15`.
 
+[i72]: https://github.com/gphotosuploader/google-photos-api-client-go/issues/72
 [i65]: https://github.com/gphotosuploader/google-photos-api-client-go/issues/65
  
 ## 2.3.0

--- a/albums/mock_repository_test.go
+++ b/albums/mock_repository_test.go
@@ -9,6 +9,7 @@ type MockedRepository struct {
 	CreateFn          func(ctx context.Context, title string) (*Album, error)
 	GetFn             func(ctx context.Context, albumId string) (*Album, error)
 	ListAllFn         func(ctx context.Context) ([]Album, error)
+	ListWithOptionsFn func(ctx context.Context, options Options) ([]Album, error)
 	GetByTitleFn      func(ctx context.Context, title string) (*Album, error)
 }
 

--- a/albums/photoslibrary_repository_test.go
+++ b/albums/photoslibrary_repository_test.go
@@ -193,3 +193,22 @@ func TestPhotosLibraryAlbumsRepository_ListAll(t *testing.T) {
 		t.Errorf("want: %d, got: %d", mocks.AvailableAlbums, len(res))
 	}
 }
+
+func TestPhotosLibraryAlbumsRepository_ListWithOptions(t *testing.T) {
+	srv := mocks.NewMockedGooglePhotosService()
+	defer srv.Close()
+
+	albumsService, err := albums.NewPhotosLibraryClientWithURL(http.DefaultClient, srv.URL())
+	if err != nil {
+		t.Fatalf("error was not expected at this point")
+	}
+
+	res, err := albumsService.ListWithOptions(context.Background(), albums.Options{ExcludeNonAppCreatedData: true})
+	if err != nil {
+		t.Fatal("error was not expected at this point")
+	}
+
+	if len(res) != mocks.AvailableAlbums {
+		t.Errorf("want: %d, got: %d", mocks.AvailableAlbums, len(res))
+	}
+}

--- a/albums/types.go
+++ b/albums/types.go
@@ -11,3 +11,14 @@ type Album struct {
 	CoverPhotoBaseURL     string
 	CoverPhotoMediaItemID string
 }
+
+// maxItemsPerPage is the maximum number of albums to ask to the PhotosLibrary. Fewer albums might
+// be returned than the specified number. See https://developers.google.com/photos/library/guides/list#pagination
+const maxItemsPerPage = 50
+
+// Options defines the options that could be customized when listing albums.
+type Options struct {
+	// ExcludeNonAppCreatedData excludes albums that were not created by this app.
+	// Defaults to false (all albums are returned).
+	ExcludeNonAppCreatedData bool
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug


**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #72 


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
Since this PR, `ListAll()` will return all the albums in the repository. Previously, we were excluding the non-app-created albums.
A new method, `ListWithOptions()` can be used to exclude them specifically.
