### PR TITLE
fix: map missing prop description in toMediaItem

### DIFF
--- a/media_items/media_items.go
+++ b/media_items/media_items.go
@@ -258,11 +258,12 @@ func New(config Config) (*Service, error) {
 
 func toMediaItem(item *photoslibrary.MediaItem) MediaItem {
 	return MediaItem{
-		ID:         item.Id,
-		ProductURL: item.ProductUrl,
-		BaseURL:    item.BaseUrl,
-		MimeType:   item.MimeType,
-		Filename:   item.Filename,
+		ID:          item.Id,
+		ProductURL:  item.ProductUrl,
+		BaseURL:     item.BaseUrl,
+		Description: item.Description,
+		MimeType:    item.MimeType,
+		Filename:    item.Filename,
 		MediaMetadata: MediaMetadata{
 			CreationTime: item.MediaMetadata.CreationTime,
 			Width:        item.MediaMetadata.Width,


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
fixes the missing mapping for MediaItem.Description, leaving all Descriptions empty when retrieving from the API


**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
no

**Does this pull request add new dependencies?**  
no

**What else do we need to know?**  
